### PR TITLE
Revert the DEFAULT_OUTPUT env var

### DIFF
--- a/src/educrawler/__main__.py
+++ b/src/educrawler/__main__.py
@@ -101,7 +101,7 @@ def main():
     """
 
     try:
-        default_output = os.environ["EC_DEFAULT_OUTPUT1"]
+        default_output = os.environ["EC_DEFAULT_OUTPUT"]
     except KeyError:
         default_output = CONST_OUTPUT_TABLE
 


### PR DESCRIPTION
According to the docs, the env var is EC_DEFAULT_OUTPUT not
EC_DEFAULT_OUTPUT1. It looks like it changed in
commit 984ab06d1bc550c5f291d96f283970a80c60d93e